### PR TITLE
Fix catalogue path. Fixes #268

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -50,7 +50,7 @@
 			}
 		},
 		"catalogue": {
-			"configFactory": "com.faboslav.friendsandfoes.modcompat.fabric.CatalogueCompat",
+			"configFactory": "com.faboslav.friendsandfoes.fabric.modcompat.CatalogueCompat",
 			"icon": {
 				"image": "catalogue_icon.png"
 			},


### PR DESCRIPTION
Fixes old path being referenced after module change in edc8d02e8de730c5bc1e5e7ed96a2145a647f986. Verified by building locally and testing game.