### PR TITLE
Fix: Crash when using Totem of Illusion on MC 1.21.1

### DIFF
--- a/common/src/main/java/com/faboslav/friendsandfoes/common/entity/PlayerIllusionEntity.java
+++ b/common/src/main/java/com/faboslav/friendsandfoes/common/entity/PlayerIllusionEntity.java
@@ -18,6 +18,8 @@ import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import org.jetbrains.annotations.Nullable;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier.Builder;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -94,6 +96,11 @@ public final class PlayerIllusionEntity extends Mob
 		}
 
 		return super.finalizeSpawn(world, difficulty, spawnReason, entityData);
+	}
+
+	public static Builder createPlayerIllusionAttributes() {
+		return Mob.createMobAttributes()
+			.add(Attributes.ATTACK_DAMAGE, 1.0);
 	}
 
 	@Override

--- a/common/src/main/java/com/faboslav/friendsandfoes/common/init/FriendsAndFoesEntityTypes.java
+++ b/common/src/main/java/com/faboslav/friendsandfoes/common/init/FriendsAndFoesEntityTypes.java
@@ -68,7 +68,7 @@ public final class FriendsAndFoesEntityTypes
 		event.register(FriendsAndFoesEntityTypes.RASCAL.get(), RascalEntity.createRascalAttributes());
 		event.register(FriendsAndFoesEntityTypes.TUFF_GOLEM.get(), TuffGolemEntity.createTuffGolemAttributes());
 		event.register(FriendsAndFoesEntityTypes.WILDFIRE.get(), WildfireEntity.createWildfireAttributes());
-		event.register(FriendsAndFoesEntityTypes.PLAYER_ILLUSION.get(), PlayerIllusionEntity.createMobAttributes());
+		event.register(FriendsAndFoesEntityTypes.PLAYER_ILLUSION.get(), PlayerIllusionEntity.createPlayerIllusionAttributes());
 	}
 
 	public static void registerEntitySpawnRestrictions(RegisterEntitySpawnRestrictionsEvent event) {


### PR DESCRIPTION
## **Problem Description**
When playing on Minecraft 1.21.1 with NeoForge, using the Totem of Illusion from `friendsandfoes-neoforge-4.0.8+mc1.21.1.jar` can cause a crash.

The crash is a `java.lang.IllegalArgumentException: Can't find attribute minecraft:generic.attack_damage`

[crash-2025-09-12_01.24.09-server.txt](https://github.com/user-attachments/files/22281995/crash-2025-09-12_01.24.09-server.txt)

## **Steps to Reproduce**
1.  Use Minecraft 1.21.1 with NeoForge.
2.  Install `friendsandfoes-neoforge-4.0.8+mc1.21.1.jar`.
3.  In-game, hold a weapon (e.g., a sword) in your main hand.
4.  Hold the Totem of Illusion in your off-hand.
5.  Take damage until your health is low enough for the totem to activate.
6.  The game crashes immediately.

## **Root Cause Analysis**
The crash occurs when `TotemUtil.createIllusion` creates a `PlayerIllusionEntity`. This entity tries to equip the player's items, including the weapon from the main hand.

The call stack is roughly:
`createIllusion` -> `equipItemIfPossible` -> `canReplaceCurrentItem` -> `getApproximateAttackDamageWithItem`

Inside `getApproximateAttackDamageWithItem`, the game attempts to get the base value of the `ATTACK_DAMAGE` attribute from the `PlayerIllusionEntity`. However, `PlayerIllusionEntity` is initialized using `Mob.createMobAttributes()`, which does not register the `ATTACK_DAMAGE` attribute. This leads to the `IllegalArgumentException`.

<details>
<summary>code shows that the attribute does not register</summary>

```java
// common\src\main\java\com\faboslav\friendsandfoes\common\init\FriendsAndFoesEntityTypes.java
public final class FriendsAndFoesEntityTypes
{
	public static void registerEntityAttributes(RegisterEntityAttributesEvent event) {
		//...
		event.register(FriendsAndFoesEntityTypes.PLAYER_ILLUSION.get(), PlayerIllusionEntity.createMobAttributes());
	}
}
```

```java
public abstract class Mob extends LivingEntity implements EquipmentUser, Leashable, Targeting {
    public static AttributeSupplier.Builder createMobAttributes() {
        return LivingEntity.createLivingAttributes().add(Attributes.FOLLOW_RANGE, 16.0);
    }
}
```

```java
public abstract class LivingEntity extends Entity implements Attackable, ILivingEntityExtension {
    public static AttributeSupplier.Builder createLivingAttributes() {
        return AttributeSupplier.builder().add(Attributes.MAX_HEALTH).add(Attributes.KNOCKBACK_RESISTANCE).add(Attributes.MOVEMENT_SPEED).add(Attributes.ARMOR).add(Attributes.ARMOR_TOUGHNESS).add(Attributes.MAX_ABSORPTION).add(Attributes.STEP_HEIGHT).add(Attributes.SCALE).add(Attributes.GRAVITY).add(Attributes.SAFE_FALL_DISTANCE).add(Attributes.FALL_DAMAGE_MULTIPLIER).add(Attributes.JUMP_STRENGTH).add(Attributes.OXYGEN_BONUS).add(Attributes.BURNING_TIME).add(Attributes.EXPLOSION_KNOCKBACK_RESISTANCE).add(Attributes.WATER_MOVEMENT_EFFICIENCY).add(Attributes.MOVEMENT_EFFICIENCY).add(Attributes.ATTACK_KNOCKBACK).add(NeoForgeMod.SWIM_SPEED).add(NeoForgeMod.NAMETAG_DISTANCE);
    }
}
```
</details>

## Why can't higher versions reproduce this problem?

In higher versions (e.g., 1.21.4), the code was refactored. The method `canReplaceCurrentItem` now delegates to `compareWeapons` for weapons, which uses `getApproximateAttributeWith`. This method first checks if the entity has the attribute using `this.getAttributes().hasAttribute(attribute)`. If the attribute is not present, it uses a default value of `0.0` instead of trying to get the attribute instance, thus avoiding the exception.

<details>
<summary>The differences among different versions</summary>

```java
// 1.21.1
public abstract class Mob extends LivingEntity implements EquipmentUser, Leashable, Targeting {
    protected boolean canReplaceCurrentItem(ItemStack candidate, ItemStack existing) {
        if (existing.isEmpty()) {
            // ...
        } else {
            if (candidate.getItem() instanceof SwordItem) {
                //...
            } else {
                Item var4 = candidate.getItem();
                if (var4 instanceof ArmorItem) {
                    // ...
                } else {
                    if (candidate.getItem() instanceof DiggerItem) {
                        if (existing.getItem() instanceof DiggerItem) {
                            d = this.getApproximateAttackDamageWithItem(candidate);
                            e = this.getApproximateAttackDamageWithItem(existing);
//...
    private double getApproximateAttackDamageWithItem(ItemStack itemStack) {
        ItemAttributeModifiers itemAttributeModifiers = (ItemAttributeModifiers)itemStack.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
        return itemAttributeModifiers.compute(this.getAttributeBaseValue(Attributes.ATTACK_DAMAGE), EquipmentSlot.MAINHAND);
    }
}



public abstract class LivingEntity extends Entity implements Attackable, ILivingEntityExtension {
    public double getAttributeBaseValue(Holder<Attribute> attribute) {
        return this.getAttributes().getBaseValue(attribute);
    }
}


public class AttributeMap {
    public double getBaseValue(Holder<Attribute> attribute) {
        AttributeInstance attributeinstance = (AttributeInstance)this.attributes.get(attribute);
        return attributeinstance != null ? attributeinstance.getBaseValue() : this.supplier.getBaseValue(attribute);
    }
}


public class AttributeSupplier {
    public double getBaseValue(Holder<Attribute> attribute) {
        return this.getAttributeInstance(attribute).getBaseValue();
    }

    private AttributeInstance getAttributeInstance(Holder<Attribute> attribute) {
        AttributeInstance attributeinstance = (AttributeInstance)this.instances.get(attribute);
        if (attributeinstance == null) {
            throw new IllegalArgumentException("Can't find attribute " + attribute.getRegisteredName()); // here it is
        } else {
            return attributeinstance;
        }
    }
}
```


```java
// >= 1.21.4
public abstract class Mob extends LivingEntity implements EquipmentUser, Leashable, Targeting {
    protected boolean canReplaceCurrentItem(ItemStack newItem, ItemStack currentItem, EquipmentSlot slot) {
        if (currentItem.isEmpty()) {
            return true;
        } else if (slot.isArmor()) {
            return this.compareArmor(newItem, currentItem, slot);
        } else {
            return slot == EquipmentSlot.MAINHAND ? this.compareWeapons(newItem, currentItem, slot) : false;
        }
    }
//...
    private boolean compareWeapons(ItemStack newItem, ItemStack currentItem, EquipmentSlot slot) {
        TagKey<Item> tagKey = this.getPreferredWeaponType();
        if (tagKey != null) {
            if (currentItem.is(tagKey) && !newItem.is(tagKey)) {
                return false;
            }

            if (!currentItem.is(tagKey) && newItem.is(tagKey)) {
                return true;
            }
        }

        double d = this.getApproximateAttributeWith(newItem, Attributes.ATTACK_DAMAGE, slot);
        double e = this.getApproximateAttributeWith(currentItem, Attributes.ATTACK_DAMAGE, slot);
        if (d != e) {
            return d > e;
        } else {
            return this.canReplaceEqualItem(newItem, currentItem);
        }
    }
//...
    private double getApproximateAttributeWith(ItemStack item, Holder<Attribute> attribute, EquipmentSlot slot) {
        double d = this.getAttributes().hasAttribute(attribute) ? this.getAttributeBaseValue(attribute) : 0.0;  // it fixed!
        ItemAttributeModifiers itemAttributeModifiers = (ItemAttributeModifiers)item.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
        return itemAttributeModifiers.compute(d, slot);
    }
}
```
</details>

## **The Fix**

The solution is to provide a dedicated attribute supplier for `PlayerIllusionEntity` that includes the `ATTACK_DAMAGE` attribute. This fix is minimal, safe, and ensures correctness on 1.21.1 without affecting other versions.

```java
// common\src\main\java\com\faboslav\friendsandfoes\common\init\FriendsAndFoesEntityTypes.java
public final class FriendsAndFoesEntityTypes
{
	public static void registerEntityAttributes(RegisterEntityAttributesEvent event) {
		//...
		event.register(FriendsAndFoesEntityTypes.PLAYER_ILLUSION.get(), PlayerIllusionEntity.createPlayerIllusionAttributes());
	}
}
```

```java
// common\src\main\java\com\faboslav\friendsandfoes\common\entity\PlayerIllusionEntity.java
public final class PlayerIllusionEntity extends Mob
{
	public static Builder createPlayerIllusionAttributes() {
		return Mob.createMobAttributes()
			.add(Attributes.ATTACK_DAMAGE, 1.0);
	}
}
```

I have tested this fix locally, and it resolves the crash.

## **Build & Testing Environment Notes**
While working on this fix, I encountered a couple of environment-specific issues required to successfully build and test for the 1.21.1 target. This information might be helpful for the project maintainers:

1.  **Gradle Configuration:** I had to set `org.gradle.configuration-cache=false` in my `gradle.properties` to get the project to build successfully with my setup.

2.  **Data Generation Fix for 1.21.1:** To get the data generators to run for the 1.21.1 NeoForge target, I also had to modify `neoforge/src/main/java/com/faboslav/friendsandfoes/neoforge/datagen/StructureNbtUpdaterDatagen.java`. The `@EventBusSubscriber` annotation required the MOD event bus to be specified explicitly, likely due to API differences in that version of NeoForge.

    ```diff
    - @EventBusSubscriber(modid = FriendsAndFoes.MOD_ID)
    + @EventBusSubscriber(modid = FriendsAndFoes.MOD_ID/*? <=1.21.1 {*/, bus= EventBusSubscriber.Bus.MOD /*?}*/)
    ```

    *Since this is a separate, build-related issue, I have **not included this change in this pull request** to keep it focused on the runtime crash. I am happy to submit this as a separate PR if desired.*

 