### PR TITLE
Add back support for trinkets for 1.21.11

### DIFF
--- a/common/src/main/java/com/faboslav/friendsandfoes/common/mixin/LightningRodBlockDegradableMixin.java
+++ b/common/src/main/java/com/faboslav/friendsandfoes/common/mixin/LightningRodBlockDegradableMixin.java
@@ -4,12 +4,12 @@ import net.minecraft.world.level.block.LightningRodBlock;
 import org.spongepowered.asm.mixin.Mixin;
 
 //? if <=1.21.8 {
-import net.minecraft.world.level.block.ChangeOverTimeBlock;
+/*import net.minecraft.world.level.block.ChangeOverTimeBlock;
 import net.minecraft.world.level.block.WeatheringCopper;
-//?}
+*///?}
 
 //? if <=1.21.8 {
-@Mixin(value = LightningRodBlock.class, priority = 1003)
+/*@Mixin(value = LightningRodBlock.class, priority = 1003)
 public abstract class LightningRodBlockDegradableMixin implements ChangeOverTimeBlock
 {
 	@Override
@@ -17,9 +17,9 @@ public abstract class LightningRodBlockDegradableMixin implements ChangeOverTime
 		return WeatheringCopper.WeatherState.UNAFFECTED;
 	}
 }
-//?} else {
-/*@Mixin(value = LightningRodBlock.class)
+*///?} else {
+@Mixin(value = LightningRodBlock.class)
 public abstract class LightningRodBlockDegradableMixin
 {
 }
-*///?}
+//?}

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -16,6 +16,7 @@ fletchingTable {
 stonecutter {
 	constants["modMenu"] = commonMod.depOrNull("mod_menu") != null
 	constants["trinkets"] = commonMod.depOrNull("trinkets") != null
+	constants["trinkets-canary-fork"] = commonMod.depOrNull("trinkets-canary-fork") != null
 }
 
 dependencies {
@@ -50,6 +51,15 @@ dependencies {
 	// Trinkets (https://www.curseforge.com/minecraft/mc-mods/trinkets)
 	commonMod.depOrNull("trinkets")?.let { trinketsVersion ->
 		modImplementation("dev.emi:trinkets:${trinketsVersion}")
+	}
+
+	commonMod.depOrNull("trinkets-canary-fork")?.let { trinketsCanaryVersion -> 
+		modImplementation("maven.modrinth:trinkets-canary-fork:${trinketsCanaryVersion}") 
+
+		commonMod.depOrNull("cca")?.let { ccaVersion ->
+			modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-base:$ccaVersion")
+			modImplementation("org.ladysnake.cardinal-components-api:cardinal-components-entity:$ccaVersion")
+		}
 	}
 
 	/*

--- a/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/modcompat/TrinketsCompat.java
+++ b/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/modcompat/TrinketsCompat.java
@@ -1,7 +1,7 @@
 package com.faboslav.friendsandfoes.fabric.modcompat;
 
-//? trinkets {
-/*import com.faboslav.friendsandfoes.common.modcompat.ModCompat;
+//? trinkets || trinkets-canary-fork {
+import com.faboslav.friendsandfoes.common.modcompat.ModCompat;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,4 +35,4 @@ public final class TrinketsCompat implements ModCompat
 		return null;
 	}
 }
-*///?}
+//?}

--- a/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/platform/PlatformCompat.java
+++ b/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/platform/PlatformCompat.java
@@ -2,10 +2,10 @@ package com.faboslav.friendsandfoes.fabric.platform;
 
 import com.faboslav.friendsandfoes.common.FriendsAndFoes;
 
-//? trinkets {
-/*import com.faboslav.friendsandfoes.fabric.modcompat.TrinketsCompat;
+//? trinkets || trinkets-canary-fork {
+import com.faboslav.friendsandfoes.fabric.modcompat.TrinketsCompat;
 import com.faboslav.friendsandfoes.common.modcompat.ModChecker;
-*///?}
+//?}
 
 public final class PlatformCompat implements com.faboslav.friendsandfoes.common.platform.PlatformCompat
 {
@@ -14,10 +14,10 @@ public final class PlatformCompat implements com.faboslav.friendsandfoes.common.
 		String modId = "";
 
 		try {
-			//? trinkets {
-			/*modId = "trinkets";
+			//? trinkets || trinkets-canary-fork {
+			modId = "trinkets";
 			ModChecker.loadModCompat(modId, () -> new TrinketsCompat());
-			*///?}
+			//?}
 		} catch (Throwable e) {
 			FriendsAndFoes.getLogger().error("Failed to setup compat with " + modId);
 			e.printStackTrace();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
         maven("https://maven.minecraftforge.net")
         maven("https://maven.kikugie.dev/snapshots")
 		maven("https://maven.kikugie.dev/releases")
+		maven("https://api.modrinth.com/maven")
     }
 }
 

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=2.5.5
 deps.yacl=3.6.6+1.20.6
 deps.mod_menu=10.0.0
 deps.trinkets=3.9.0
+deps.trinkets-canary-fork=
 deps.curios=8.1.0+1.20.6

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=3.0.12
 deps.yacl=3.6.5+1.21.1
 deps.mod_menu=11.0.1
 deps.trinkets=3.10.0
+deps.trinkets-canary-fork=
 deps.curios=9.4.0+1.21.1

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=3.9.0
 deps.yacl=3.8.0+1.21.9
 deps.mod_menu=16.0.0-rc.1
 deps.trinkets=
+deps.trinkets-canary-fork=
 deps.curios=

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -24,4 +24,6 @@ deps.resourceful-lib.lib=3.11.0
 deps.yacl=3.8.1+1.21.11
 deps.mod_menu=
 deps.trinkets=
+deps.trinkets-canary-fork=3.11.2
+deps.cca=7.3.0
 deps.curios=

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=3.4.5
 deps.yacl=3.6.5+1.21.4
 deps.mod_menu=13.0.2
 deps.trinkets=
+deps.trinkets-canary-fork=
 deps.curios=

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=3.5.0
 deps.yacl=3.6.6+1.21.5
 deps.mod_menu=14.0.0-rc.2
 deps.trinkets=
+deps.trinkets-canary-fork=
 deps.curios=

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -24,4 +24,5 @@ deps.resourceful-lib.lib=3.6.0
 deps.yacl=3.7.1+1.21.6
 deps.mod_menu=15.0.0
 deps.trinkets=
+deps.trinkets-canary-fork=
 deps.curios=


### PR DESCRIPTION
Adds support for trinkets in 1.21.11 via the [Trinkets Canary Fork](https://github.com/Rebel459/trinkets-canary). Fixes #415