### PR TITLE
Fix Fabric Trinkets Updated compatibility

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -46,7 +46,9 @@ dependencies {
 	// Compat dependencies
 	// Trinkets (https://www.curseforge.com/minecraft/mc-mods/trinkets)
 	commonMod.depOrNull("trinkets")?.let { trinketsVersion ->
-		if (commonMod.mc == "1.21.1") {
+		if (stonecutter.eval(commonMod.mc, ">=26.1")) {
+			modImplementation(fletchingTable.modrinth("trinkets-updated", commonMod.mc, "fabric"))
+		} else if (commonMod.mc == "1.21.1") {
 			modImplementation("dev.emi:trinkets:${trinketsVersion}")
 		} else {
 			modImplementation(fletchingTable.modrinth("trinkets-canary", commonMod.mc, "fabric"))

--- a/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/modcompat/TrinketsCompat.java
+++ b/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/modcompat/TrinketsCompat.java
@@ -1,7 +1,7 @@
 package com.faboslav.friendsandfoes.fabric.modcompat;
 
 //? if trinkets {
-/*import com.faboslav.friendsandfoes.common.modcompat.ModCompat;
+import com.faboslav.friendsandfoes.common.modcompat.ModCompat;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -10,10 +10,16 @@ import java.util.List;
 import java.util.function.Predicate;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
-import dev.emi.trinkets.api.SlotReference;
+
+//? if >=26.1 {
+import eu.pb4.trinkets.api.TrinketSlotAccess;
+import eu.pb4.trinkets.api.TrinketsApi;
+//?} else {
+/*import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.TrinketsApi;
+*///?}
 
 public final class TrinketsCompat implements ModCompat
 {
@@ -25,14 +31,19 @@ public final class TrinketsCompat implements ModCompat
 	@Override
 	@Nullable
 	public ItemStack getEquippedItemFromCustomSlots(Entity entity, Predicate<ItemStack> itemStackPredicate) {
-		if (entity instanceof Player player) {
-			return TrinketsApi.getTrinketComponent(player).map(component -> {
+		if (entity instanceof LivingEntity livingEntity) {
+			//? if >=26.1 {
+			List<Tuple<TrinketSlotAccess, ItemStack>> res = TrinketsApi.getAttachment(livingEntity).getEquipped(itemStackPredicate);
+			return !res.isEmpty() ? res.get(0).getB() : null;
+			//?} else {
+			/*return TrinketsApi.getTrinketComponent(livingEntity).map(component -> {
 				List<Tuple<SlotReference, ItemStack>> res = component.getEquipped(itemStackPredicate);
-				return !res.isEmpty() ? res.get(0).getB():null;
+				return !res.isEmpty() ? res.get(0).getB() : null;
 			}).orElse(null);
+			*///?}
 		}
 
 		return null;
 	}
 }
-*///?}
+//?}

--- a/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/platform/PlatformCompat.java
+++ b/fabric/src/main/java/com/faboslav/friendsandfoes/fabric/platform/PlatformCompat.java
@@ -1,11 +1,11 @@
 package com.faboslav.friendsandfoes.fabric.platform;
 
 import com.faboslav.friendsandfoes.common.FriendsAndFoes;
+import com.faboslav.friendsandfoes.common.modcompat.ModChecker;
 
 //? if trinkets {
-/*import com.faboslav.friendsandfoes.fabric.modcompat.TrinketsCompat;
-import com.faboslav.friendsandfoes.common.modcompat.ModChecker;
-*///?}
+import com.faboslav.friendsandfoes.fabric.modcompat.TrinketsCompat;
+//?}
 
 public final class PlatformCompat implements com.faboslav.friendsandfoes.common.platform.PlatformCompat
 {
@@ -15,9 +15,12 @@ public final class PlatformCompat implements com.faboslav.friendsandfoes.common.
 
 		try {
 			//? if trinkets {
-			/*modId = "trinkets";
+			modId = "trinkets";
+			//? if >=26.1 {
+			modId = "trinkets_updated";
+			//?}
 			ModChecker.loadModCompat(modId, () -> new TrinketsCompat());
-			*///?}
+			//?}
 		} catch (Throwable e) {
 			FriendsAndFoes.getLogger().error("Failed to setup compat with " + modId);
 			e.printStackTrace();

--- a/fabric/src/main/resources/data/trinkets/slots/charm/charm.json
+++ b/fabric/src/main/resources/data/trinkets/slots/charm/charm.json
@@ -1,3 +1,0 @@
-{
-	"icon": "trinkets:gui/slots/charm"
-}

--- a/fabric/src/main/resources/data/trinkets/slots/charm/charm.json5
+++ b/fabric/src/main/resources/data/trinkets/slots/charm/charm.json5
@@ -1,0 +1,7 @@
+{
+	//? if >=26.1 {
+	"icon": "trinkets:container/slots/charm"
+	//?} else {
+	/*"icon": "trinkets:gui/slots/charm"
+	*///?}
+}

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -23,5 +23,5 @@ deps.resourceful_lib.mc=26.1
 deps.resourceful_lib.lib=4.0.0
 deps.yacl=3.9.1+26.1
 deps.mod_menu=18.0.0-alpha.8
-deps.trinkets=
+deps.trinkets=4.0.0-alpha.9+26.1
 deps.curios=


### PR DESCRIPTION
## Summary
- Restore Fabric Trinkets compat for MC 26.1 / Trinkets Updated using the direct `eu.pb4.trinkets` API for 26.1+ builds.
- Keep legacy Fabric builds on the existing `dev.emi.trinkets` API path.
- Resolve `trinkets-updated` as the Fabric compat dependency for 26.1+ while preserving Trinkets / Trinkets Canary for older targets.
- Convert the charm slot definition to Stonecutter-processed JSON5 so 26.1+ uses `trinkets:container/slots/charm` and older versions keep `trinkets:gui/slots/charm`.

## Why
Trinkets Updated 4.x for MC 26.1 changed both the public API package and GUI slot sprite path. Friends & Foes still registered its Trinkets charm slot, but on MC 26.1.2 with Trinkets Updated the slot icon rendered as a missing texture and Friends & Foes totems equipped in that slot were not found by the custom equipment slot compat lookup.

This keeps the compatibility version-gated instead of applying the new sprite path or API globally, because the current 1.21.x Fabric targets still use the legacy API and `trinkets:gui/slots/*` resource path.

## Gameplay note
This PR keeps the existing Friends & Foes behavior: when Trinkets is installed, Friends & Foes provides a dedicated `charm/charm` Trinkets slot that can hold totems. The change here only restores that existing Fabric integration for Trinkets Updated / MC 26.1.

That slot does have gameplay impact because it allows totems to be equipped outside the main hand or offhand. If that behavior is considered too implicit for modpacks where Trinkets is present because of another mod, it may be worth making the Friends & Foes Trinkets totem slot configurable or moving it to an optional datapack in a separate follow-up.

## Verification
- `sh ./gradlew :fabric:26.1.2:build`
- `sh ./gradlew :fabric:1.21.1:build :fabric:1.21.11:build`
- `sh ./gradlew :fabric:1.21.4:build :fabric:1.21.5:build :fabric:1.21.8:build :fabric:1.21.10:build`
- Verified generated `fabric-26.1.2` jar contains `data/trinkets/slots/charm/charm.json` with `trinkets:container/slots/charm`.
- Verified generated legacy Fabric jars keep `data/trinkets/slots/charm/charm.json` with `trinkets:gui/slots/charm`.
- Locally tested MC 26.1.2 with Trinkets Updated: the charm slot no longer shows the missing-texture icon and Friends & Foes totems equipped in the slot trigger correctly.